### PR TITLE
feat(ui): new hero gradient + Space Grotesk/Inter typography

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=Poppins:wght@600&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&family=Space+Grotesk:wght@600;700&display=swap" rel="stylesheet" />
     <title>NovaFrame Realty</title>
   </head>
   <body>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,7 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
-import './index.css'
+import './styles/globals.css'
 import App from './App.tsx'
 
 createRoot(document.getElementById('root')!).render(

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -3,8 +3,8 @@ import { Link } from 'react-router-dom'
 export default function Home() {
   return (
     <div>
-      <section className="relative h-[80vh] flex items-center justify-center text-white bg-animated-gradient">
-        <div className="text-center px-4">
+      <section className="relative h-[80vh] flex items-center justify-center text-white bg-hero before:absolute before:inset-0 before:bg-black/40 before:content-['']">
+        <div className="relative z-10 text-center px-4">
           <h1 className="text-4xl md:text-7xl font-heading font-bold mb-6">
             Next-Gen Property Management Software
           </h1>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -7,14 +7,16 @@
     --color-primary: #00b4d8; /* electric blue */
     --color-secondary: #1e293b; /* dark slate */
     --color-accent: #3ff69a; /* neon accent */
+    --font-heading: 'Space Grotesk', system-ui, sans-serif;
+    --font-body: 'Inter', system-ui, sans-serif;
   }
   .dark {
     --color-primary: #3ff69a;
     --color-secondary: #0f172a;
     --color-accent: #00b4d8;
   }
-  html {
-    font-family: 'Inter', sans-serif;
+  body {
+    @apply font-body;
   }
   h1,
   h2,
@@ -22,7 +24,7 @@
   h4,
   h5,
   h6 {
-    font-family: 'Poppins', sans-serif;
+    @apply font-heading;
   }
 }
 
@@ -38,25 +40,8 @@
   }
 }
 
-@keyframes gradient-move {
-  0% {
-    background-position: 0% 50%;
+@layer utilities {
+  .bg-hero {
+    @apply bg-gradient-to-br from-sky-500 via-green-500 to-teal-700;
   }
-  50% {
-    background-position: 100% 50%;
-  }
-  100% {
-    background-position: 0% 50%;
-  }
-}
-
-.bg-animated-gradient {
-  background: linear-gradient(
-    -45deg,
-    var(--color-primary),
-    var(--color-accent),
-    var(--color-secondary)
-  );
-  background-size: 400% 400%;
-  animation: gradient-move 15s ease infinite;
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,3 +1,5 @@
+import defaultTheme from 'tailwindcss/defaultTheme'
+
 /** @type {import('tailwindcss').Config} */
 export default {
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
@@ -10,8 +12,8 @@ export default {
         accent: 'var(--color-accent)',
       },
       fontFamily: {
-        sans: ['Inter', 'sans-serif'],
-        heading: ['Poppins', 'sans-serif'],
+        heading: ['var(--font-heading)', ...defaultTheme.fontFamily.sans],
+        body: ['var(--font-body)', ...defaultTheme.fontFamily.sans],
       },
       spacing: {
         128: '32rem',


### PR DESCRIPTION
## Summary
- add Space Grotesk and Inter font stacks with system fallbacks
- introduce reusable `bg-hero` utility gradient and apply to landing hero
- load Google Fonts with `font-display: swap`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68c74439cba883338d279531506d9c08